### PR TITLE
Generalize ks_stat to repeating data

### DIFF
--- a/dc_stat_think/dc_stat_think.py
+++ b/dc_stat_think/dc_stat_think.py
@@ -1088,11 +1088,14 @@ def _ks_stat(data1, data2):
     # Compute corresponding values of the theoretical CDF
     cdf = _ecdf_formal(x, data2)
 
-    # Compute distances between convex corners and CDF
+    # Compute distances between concave corners and CDF
     D_top = y - cdf
 
-    # Compute distance between concave corners and CDF
-    D_bottom = cdf - y + 1/len(data1)
+    # Compute distance between convex corners and CDF
+    
+    y_shifted = np.insert(y[:-1],obj=0,values=0)
+    D_bottom = cdf - y_shifted
+    #D_bottom = cdf - y + 1/len(data1)   
 
     return np.max(np.concatenate((D_top, D_bottom)))
 


### PR DESCRIPTION
Current implementation to get D_bottom subtracts (y - 1/len(data1)) from cdf. This assumes that the convex corner is just 1/n below the concave corner. This only happens when the data is unique. If there is repeating data, the convex corner could be multiples of 1/n below. 

y_shifted intermediate variable is added to find the convex corners. The convex corner of the current x is the concave corner of the previous x. Thus, i shifted the y values 1 index to the right, and added 0 on the left to fill up the space.

P.s i also switched the concave/convex terms in the comments in this file to be consistent with Datacamp's template and your verbal description in the video https://campus.datacamp.com/courses/case-studies-in-statistical-thinking/statistical-seismology-and-the-parkfield-region?ex=8.
 
The new implementation would find convex corners not just at 1/len(data1) below the concave corner, but also further below.
I can't find the random seed used in Datacamp, so I have tested this using my own np.random.seed(1) to get p = 0.246 for np.random.exponential with both the old and new implementation. Would you suggest more formal testing methods? I have no experience in testing and code coverage reports at all so my jupyter test doesn't feel robust against your functions that have numba and involve _single_leading_underscore 