### PR TITLE
bug: remove unknown module prefix in b_value function

### DIFF
--- a/dc_stat_think/dc_stat_think.py
+++ b/dc_stat_think/dc_stat_think.py
@@ -880,7 +880,7 @@ def b_value(mags, mt, perc=[2.5, 97.5], n_reps=None):
     if n_reps is None:
         return b
     else:
-        m_bs_reps = dcst.draw_bs_reps(m, np.mean, size=n_reps)
+        m_bs_reps = draw_bs_reps(m, np.mean, size=n_reps)
 
         # Compute b-value from replicates
         b_bs_reps = (m_bs_reps - mt) * np.log(10)

--- a/dc_stat_think/no_numba.py
+++ b/dc_stat_think/no_numba.py
@@ -883,7 +883,7 @@ def b_value(mags, mt, perc=[2.5, 97.5], n_reps=None):
     if n_reps is None:
         return b
     else:
-        m_bs_reps = dcst.draw_bs_reps(m, np.mean, size=n_reps)
+        m_bs_reps = draw_bs_reps(m, np.mean, size=n_reps)
 
         # Compute b-value from replicates
         b_bs_reps = (m_bs_reps - mt) * np.log(10)

--- a/dc_stat_think/original.py
+++ b/dc_stat_think/original.py
@@ -177,7 +177,7 @@ def b_value(mags, mt, perc=[2.5, 97.5], n_reps=None):
     if n_reps is None:
         return b
     else:
-        m_bs_reps = dcst.draw_bs_reps(m, np.mean, size=n_reps)
+        m_bs_reps = draw_bs_reps(m, np.mean, size=n_reps)
 
         # Compute b-value from replicates
         b_bs_reps = (m_bs_reps - mt) * np.log(10)


### PR DESCRIPTION
Your datacamp courses are awesome: All hail the power of bootstrap samples. I've been following along in my local notebook, but found a bug in the b_value function, it calls a module prefix that doesn't exist in the module itself. This is corrected in this pull request.